### PR TITLE
Add Sonoff Mini ZBRBS cover

### DIFF
--- a/zhaquirks/sonoff/mini_zbrbs.py
+++ b/zhaquirks/sonoff/mini_zbrbs.py
@@ -1,0 +1,118 @@
+"""Sonoff Mini ZB RBS - Zigbee Cover."""
+
+from zigpy.quirks import CustomCluster
+from zigpy.quirks.v2 import EntityPlatform, EntityType, QuirkBuilder
+import zigpy.types as t
+from zigpy.zcl import foundation
+from zigpy.zcl.foundation import BaseAttributeDefs, ZCLAttributeDef
+
+
+class SonoffCluster(CustomCluster):
+    """Custom Sonoff cluster."""
+
+    cluster_id = 0xFC11
+
+    manufacturer_id_override = foundation.ZCLHeader.NO_MANUFACTURER_ID
+
+    class AttributeDefs(BaseAttributeDefs):
+        """Attribute definitions."""
+
+        external_trigger_mode = ZCLAttributeDef(
+            id=0x0016,
+            type=t.uint8_t,
+            is_manufacturer_specific=True,
+        )
+        cover_calibrated = ZCLAttributeDef(
+            id=0x5012,
+            type=t.uint8_t,
+            is_manufacturer_specific=True,
+        )
+        cover_status = ZCLAttributeDef(
+            id=0x5013,
+            type=t.uint8_t,
+            is_manufacturer_specific=True,
+            access="r",
+        )
+        attrib_0010 = ZCLAttributeDef(  # factory value=515
+            id=0x0010,
+            type=t.uint32_t,
+            is_manufacturer_specific=True,
+            access="r",
+        )
+        attrib_0012 = ZCLAttributeDef(  # factiry value=10
+            id=0x0012,
+            type=t.int16s,
+            is_manufacturer_specific=True,
+        )
+        limits_calibration = ZCLAttributeDef( # 2: automatic calibration, 4: not_calibrated_+open 50% , 6: stop(in pairing)?, 7: manual pairing?+close, 8: stop+stop_pairing
+            id=0x5001,
+            type=t.uint8_t,
+            is_manufacturer_specific=True,
+        )
+        cluster_revision = ZCLAttributeDef(
+            id=0xfffd,
+            type=t.uint16_t,
+            is_manufacturer_specific=True,
+        )
+
+
+class SonoffCoverCalibrationStatus(t.enum8):
+    """extern switch trigger type."""
+
+    not_calibrated = 0x00
+    calibrated = 0x01
+
+
+class SonoffCoverStatus(t.enum8):
+    """extern switch trigger type."""
+
+    stopped = 0x00
+    opening = 0x01
+    closing = 0x02
+
+
+class SonoffExternalSwitchTriggerType(t.enum8):
+    """extern switch trigger type."""
+
+    edge_trigger = 0x00
+    pulse_trigger = 0x01
+
+
+(
+    QuirkBuilder("SONOFF", "MINI-ZBRBS")
+    .replaces(SonoffCluster)
+    .enum(
+        SonoffCluster.AttributeDefs.external_trigger_mode.name,
+        SonoffExternalSwitchTriggerType,
+        SonoffCluster.cluster_id,
+        translation_key="external_trigger_mode",
+        fallback_name="External trigger mode",
+    )
+    .enum(
+        SonoffCluster.AttributeDefs.cover_calibrated.name,
+        SonoffCoverCalibrationStatus,
+        SonoffCluster.cluster_id,
+        entity_platform = EntityPlatform.SENSOR,
+        entity_type = EntityType.DIAGNOSTIC,
+        translation_key="cover_calibrated",
+        fallback_name="Calibrated",
+    )
+    .enum(
+        SonoffCluster.AttributeDefs.cover_status.name,
+        SonoffCoverStatus,
+        SonoffCluster.cluster_id,
+        entity_platform = EntityPlatform.SENSOR,
+        entity_type = EntityType.DIAGNOSTIC,
+        initially_disabled = True,
+        translation_key="cover_status",
+        fallback_name="Cover status",
+    )
+    .write_attr_button(
+        SonoffCluster.AttributeDefs.limits_calibration.name,
+        2,  # 2: automatic calibration
+        SonoffCluster.cluster_id,
+        translation_key="configure_limits",
+        fallback_name="Configure cover limits",
+    )
+    .add_to_registry()
+)


### PR DESCRIPTION
## Proposed change
<!--
  Explain your proposed change below.
-->
Adds the Sonoff MINI ZBRBS cover quirk.

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->
All the functionality can be accessed from the device's button, but I think it's more practical to expose it using this quirk.


The implemented functionalities are:
* External trigger mode (short press button x3)
* Automatic limits configuration (hold button > 10s)
* Cover calibration status sensor

The remaining cluster attributes can be read from the "Manage Zigbee device" option. There are 2 unknown attributes:
* 0x0010 (factory value 515)
* 0x0012 (factory value 10)

I think it would be interesting to implement a workflow to allow manual (in addition to automatic) limit configuration. I believe I've seen something similar implemented somewhere (launching a workflow from the device settings), but I haven't been able to locate it (and I'm not sure if it would be possible to implement it from a quirk). For now, we only have the option of automatic configuration.

The `cover_status` entity has been added but disabled. Although it doesn't provide relevant information, it can be useful when creating automations. 

## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->
[zha-01KCD5D01VQYCT0HG3EAYSAFVF-SONOFF MINI-ZBRBS-d4136b73cf379046720b391adee464be.json](https://github.com/user-attachments/files/24265385/zha-01KCD5D01VQYCT0HG3EAYSAFVF-SONOFF.MINI-ZBRBS-d4136b73cf379046720b391adee464be.json)


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [x] Device diagnostics data has been attached
